### PR TITLE
Fix compile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ LDFLAGS=-nostartfiles
 all:
 	$(CC) -g source/*.c $(CFLAGS)
 	$(CC) -g source/*.s $(CFLAGS)
+	mkdir -p obj
 	cp *.o ./obj
 	$(CC) -T 3ds.ld *.o $(LDFLAGS)
 	cp a.out ./bin/homebrew.elf


### PR DESCRIPTION
Fixed issue in makefile where user cannot compile due to missing 'obj' folder.
New makefile fixes issue by creating an 'obj' folder before it's accessed
